### PR TITLE
Update bound_claims for use of TFC Projects

### DIFF
--- a/vault_config/README.md
+++ b/vault_config/README.md
@@ -27,7 +27,7 @@ These are Terraform and environment variable values that you should set:
 * `vault_namespace` = Terraform variable to set the Vault namespace (if using Vault Enterprise or HCP Vault)
 * `tfc_workspace` = The TFC workspace that will access the secret
 * `tfc_organization` = The TFC organization containing the workspace
-* `tfc_project` = The TFC project in which the workspace is associated - default is "default"
+* `tfc_project` = The TFC project in which the workspace is associated - default is "Default Project"
 
 Once you have those values set, you can deploy the configuration with the following commands:
 

--- a/vault_config/README.md
+++ b/vault_config/README.md
@@ -27,6 +27,7 @@ These are Terraform and environment variable values that you should set:
 * `vault_namespace` = Terraform variable to set the Vault namespace (if using Vault Enterprise or HCP Vault)
 * `tfc_workspace` = The TFC workspace that will access the secret
 * `tfc_organization` = The TFC organization containing the workspace
+* `tfc_project` = The TFC project in which the workspace is associated - default is "default"
 
 Once you have those values set, you can deploy the configuration with the following commands:
 

--- a/vault_config/main.tf
+++ b/vault_config/main.tf
@@ -63,7 +63,7 @@ resource "vault_jwt_auth_backend_role" "example" {
   bound_audiences   = ["vault.testing"]
   bound_claims_type = "glob"
   bound_claims = {
-    sub = "organization:${var.tfc_organization}:workspace:${var.tfc_workspace}:run_phase:*"
+    sub = "organization:${var.tfc_organization}:workspace:${var.tfc_workspace}:run_phase:*,organization:${var.tfc_organization}:project:${var.tfc_project}:workspace:${var.tfc_workspace}:run_phase:*"
   }
   user_claim = "terraform_full_workspace"
   role_type  = "jwt"

--- a/vault_config/variables.tf
+++ b/vault_config/variables.tf
@@ -18,3 +18,9 @@ variable "tfc_workspace" {
   type        = string
   description = "(Required) The name of the TFC workspace"
 }
+
+variable "tfc_project" {
+  type        = string
+  description = "(Required) The name of the TFC project in which the workspace is associated"
+  default     = "default"
+}

--- a/vault_config/variables.tf
+++ b/vault_config/variables.tf
@@ -22,5 +22,5 @@ variable "tfc_workspace" {
 variable "tfc_project" {
   type        = string
   description = "(Required) The name of the TFC project in which the workspace is associated"
-  default     = "default"
+  default     = "Default Project"
 }


### PR DESCRIPTION
Per hashi docs, an update is required for the bound_claims due to the release of projects in TFC.
https://support.hashicorp.com/hc/en-us/articles/13138701895699-Updating-Workload-Identity-for-Projects